### PR TITLE
camera-thread -> daemon, rm stop()

### DIFF
--- a/duckietown_slimremote/pc/camera.py
+++ b/duckietown_slimremote/pc/camera.py
@@ -42,7 +42,7 @@ class SubCameraMaster():
     def __init__(self, host):
         self.queue = LifoQueue(2)
         self.cam_thread = ThreadedSubCamera(self.queue, host)
-        # self.cam_thread.daemon = True
+        self.cam_thread.daemon = True
         self.cam_thread.start()
         self.last_img = None
 
@@ -56,10 +56,6 @@ class SubCameraMaster():
             return self.last_img
         else:
             return None
-
-    def stop(self):
-        # TODO: implement this
-        pass
 
 
 def cam_window_init():


### PR DESCRIPTION
Just making the camera thread a daemon, so we no longer need to manually stop the thread.

Also, makes the ROS node much easier to Ctrl-C (without the need to register exit handlers).