### PR TITLE
reset() method now returns an observation. Fixes #5

### DIFF
--- a/duckietown_slimremote/pc/robot.py
+++ b/duckietown_slimremote/pc/robot.py
@@ -83,6 +83,8 @@ class RemoteRobot():
     def reset(self):
         msg = construct_action(self.id, action=RESET)
         self.robot_sock.send_string(msg)
+        obs, _, _, _ = self.observe()
+        return obs
         # print("sent reset")
 
 


### PR DESCRIPTION
Updated the `reset()` method in https://github.com/duckietown/duckietown-slimremote/blob/3e4ec7e2995b82b618d20c580d44cf207dd47540/duckietown_slimremote/pc/robot.py#L83

to enable a fix for #5 and ultimately for duckietown/gym-duckietown-agent#6