### PR TITLE
Fixes for running the slimremote on the duckiebot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt update -y && \
         libilmbase-dev \
         libfreetype6-dev \
         libgstreamer1.0-dev \
+        libc6 \
         libatlas-base-dev && \
     apt install -y --no-install-recommends libpng12-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If your Duckiebot is running HypriotOS/DuckieOS, you can run duckietown-slimremo
 
 The following command will start the motor contoller and image server:
 
-    docker run -dit --privileged duckietown/duckietown-slimremote
+    docker run -dit -p 5558:5558 --privileged duckietown/duckietown-slimremote
 
 ### Building 
 


### PR DESCRIPTION
If someone wants to run the slimremote directly on a Docukiebot without the rest of the containerization infrastructure, these fixes should be added to the Dockerfile.

I guess exporting the port is probably a more general problem?