### PR TITLE
Small fixes to the Slimremote containerization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If your Duckiebot is running HypriotOS/DuckieOS, you can run duckietown-slimremo
 
 The following command will start the motor contoller and image server:
 
-    docker run -dit -p 5558:5558 --privileged duckietown/duckietown-slimremote
+    docker run -dit -p 5558:5558 -p 8902:8902 --privileged duckietown/duckietown-slimremote
 
 ### Building 
 

--- a/duckietown_slimremote/robot/motors.py
+++ b/duckietown_slimremote/robot/motors.py
@@ -172,7 +172,7 @@ def make_async_controller(base):
                         self.robot.list_action([0, 0])
                         self.robot.rgb_off()
                     else:
-                        ik = self.robot.ik_action(action[:2])
+                        ik = self.robot.ik_action(v=action[0], omega=action[1])
                         if len(action) == 5:
                             self.robot.rgb_action(action[2:])
 


### PR DESCRIPTION
1. ik_action was called with only one parameter (and expects two v, omega).

2. Port 8902 should be mapped to the 8902 port in the host.
